### PR TITLE
Fixed errors from edge-case inputs in `get_obj_addr` and `get_obj_name`

### DIFF
--- a/R/get_obj_address.r
+++ b/R/get_obj_address.r
@@ -1,8 +1,8 @@
 #' Return the memory address of an object
-#' 
+#'
 #' Return the memory address of an object after recursively searching for the object in all the environments defined
 #' in a specified environment or in all the environments defined in the whole workspace.
-#' 
+#'
 #' @param obj object whose memory address is requested. It can be given as a variable name or an expression.
 #' Strings representing object names are not interpreted and return \code{NULL}.
 #' @param envir environment where the object should be searched for. All parent environments of
@@ -23,14 +23,14 @@
 #' The object is first searched recursively in all environments defined in the specified environment (if any),
 #' by calling \code{obj_find}.
 #' If no environment is specified, the object is searched recursively in the whole workspace.
-#' 
+#'
 #' The memory address is then retrieved for every object found in those environments having the same name
 #' as the given object \code{obj}.
-#' 
+#'
 #' Strings return \code{NULL} but strings can be the result of an expression passed as argument to this function.
 #' In that case, the string is interpreted as an object and its memory address is returned as long as
 #' the object exists.
-#' 
+#'
 #' If \code{envmap} is passed it should be a data frame providing an address-name pair lookup table
 #' of environments and should contain at least the following columns:
 #' \itemize{
@@ -49,8 +49,8 @@
 #' Such \code{envmap} data frame can be created by calling \link{get_env_names}.
 #' Use this parameter with care, as the matrix passed may not correspond to the actual mapping of existing
 #' environments to their addresses and in that case results may be different from those expected.
-#' 
-#' @return 
+#'
+#' @return
 #' The 8-digit (32-bit architectures) thru 16-digit (64-bit architectures) memory address of
 #' the input object given as a string enclosed in <>  (e.g. \code{"<0000000005E90988>"})
 #' (note that Ubuntu Debian may use 12-digit memory addresses),
@@ -63,16 +63,16 @@
 #' \item the object does not exist in the given environment.
 #' \item the object is an expression that cannot be evaluated in the given environment.
 #' }
-#' 
+#'
 #' Note that for the last case, although constants have a memory address, this address is meaningless as
 #' it changes with every invocation of the function. For instance, running
 #' \code{address(3)} several times will show a different memory address each time, and that is why
 #' \code{get_obj_address} returns \code{NULL} in those cases.
-#' 
+#'
 #' When \code{envir=NULL} (the default) or when an object exists in several environments,
 #' the memory address is returned for all of the environments where the object is found. In that case, the addresses are
 #' stored in an array whose names attribute shows the environments where the object is found.
-#' 
+#'
 #' @examples
 #' env1 = new.env()
 #' env1$x = 3                       # x defined in environment 'env1'
@@ -84,14 +84,14 @@
 #'                                  # returns a named array with the memory address of all its
 #'                                  # occurrences, where the names are the names of the
 #'                                  # environments where x was found.
-#' 
+#'
 #' # Memory addresses of objects whose names are stored in an array and retrieved using sapply()
 #' env1$y <- 2;
 #' objects <- c("x", "y")
 #' sapply(objects, FUN=get_obj_address, envir=env1)	# Note that the address of object "x"
 #'                                                  # is the same as the one returned above
 #'                                                  # by get_obj_address(x, envir=env1)
-#' 
+#'
 #' # Memory address of elements of a list
 #' alist <- list("x")
 #' get_obj_address(alist[[1]])      # memory address of object 'x'
@@ -113,7 +113,7 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
 			obj_name = get_obj_name(obj, n=n+1, silent=TRUE)
 			if (!is.null(obj_name) && obj_name != "" && exists(obj_name, envir=envir, inherits=FALSE)) {
 				## NOTE: The conditions !is.null() and != "" are in place because these are not valid arguments for the
-				## exists() function. All the other names including invalid names such as "<a" are valid arguments for exists(). 
+				## exists() function. All the other names including invalid names such as "<a" are valid arguments for exists().
 				obj_address = address(eval(as.name(obj_name), envir=envir))  # This eval() does NOT need to be enclosed in try() because the object exists() in 'envir'
 				## NOTE: we are using eval(as.name(obj_name)) instead of eval(obj).
 				## It's strange that the latter does not work because eval() first evaluates obj in the calling environment
@@ -122,8 +122,8 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
 				## is not found when envir is not the Global Environment!
 				## We can neither use evalq() because evalq() prevents 'obj' from being evaluated in the
 				## current execution environment and in that case the address() function would be returning
-				## the memory address of the local variable 'obj', not of the variable referenced by 'obj'!  
-				
+				## the memory address of the local variable 'obj', not of the variable referenced by 'obj'!
+
 				## NOTE also that eval() presumably looks for the object recursively in all parent environments
 				## if it is not found in the 'envir' environment, so in principle it does the same thing that
 				## exists() does when inherits=TRUE, and we should be ok here in that eval() should not give an
@@ -131,7 +131,7 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
 			} else {
 				obj_address = NULL
 			}
-			
+
 			if (is.null(obj_address)) {
 			  #---- 2.- Check if 'obj' was given as an expression that includes the environment path -----
 			  # This is the case when e.g. obj = env1$x, where env1 is an environment
@@ -152,7 +152,7 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
 
 			 if (is.null(obj_address)) {
 			    # Still the object's address could not be retrieved...
-			    
+
 			    #------------ 3. Try to retrieve the object's address after evaluating the object --------
 			    # This is the case when e.g. obj is an expression as in 'objects[1]'
 			    # Note that we set the warn option to "no warning" in order to
@@ -218,7 +218,8 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
 	set_option_warn_to_nowarning()
 	is_obj_null_na_string = try( is_null_or_na(obj) || is_string(obj), silent=TRUE )
 	reset_option_warn()
-	if (!inherits(is_obj_null_na_string, "try-error") && is_obj_null_na_string) {
+	# is_obj_null_na_string can evaluate to NA in some cases, NA is treated as false here.
+	if (!inherits(is_obj_null_na_string, "try-error") && isTRUE(is_obj_null_na_string)) {
 	  return(NULL)
 	}
 
@@ -265,7 +266,7 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
   					# envir=.GlobalEnv in this case.
   				  # - setting envir=.GlobalEnv is not a problem of overriding the 'envir' parameter because
   				  # we don't even get to this point when the envir parameter is set to a particular environment
-  				  # since these statements are part of the block 'if (is.null(envir))'. 
+  				  # since these statements are part of the block 'if (is.null(envir))'.
   					obj_addresses = c(obj_addresses, get_obj_address0(obj, envir=.GlobalEnv, n=n+1))
   				} else {
   					# Check whether the environment whose name is 'envir_name' is a "user-defined environment or a function
@@ -276,7 +277,7 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
   						# It's a user-defined or function environment
   					  # => Get the environment object associated to 'envir_name' by evaluating envir_name as an expression
   					  # (i.e. using parse() to convert the string in 'envir_name' to an expression)
-  					  
+
   					  # Notes:
   					  # - we evaluate the expression in envir=parent.frame(). This is important to avoid name collision
   					  # when envir_name happens to be "e" (i.e. the user has defined an environment with name "e"), whose name
@@ -290,7 +291,7 @@ get_obj_address = function(obj, envir=NULL, envmap=NULL, n=0, include_functions=
   					  # pairs map! (the user could pass anything... even this happened in Sep-2017 when testing the package
   					  # where a completely controlled environment generated an inconsistent envmap table --recall this case with
   					  # the "object 'doTryCatch' not found" error triggered from test-get_obj_value.r)
-  					  
+
   					  # First get the environment as if it were an user-defined environment (as opposed to a function execution environment)
   					  # Note that we DESTANDARDIZE the environment name 'envir_name' in case the user-defined environment
   					  # is given as in e.g. "R_GlobalEnv$env1", in which case the eval-parse-ing of it will not find env1

--- a/R/get_obj_name.r
+++ b/R/get_obj_name.r
@@ -1,14 +1,14 @@
 #' Return the name of an object at a given parent generation from an environment
-#' 
+#'
 #' A practical use of this function is to retrieve the name of the object leading to
 #' a function's parameter in the function calling chain, at any parent generation.
-#' 
+#'
 #' In particular, it provides a handy way of retrieving the name of a function's parameter
 #' and use it in e.g. messages to the user describing the arguments received by the function.
 #' In this context, it is a shortcut to calling \code{as.list(environment())}, which returns
 #' a list of parameter names and parameter values.
 #' See the Examples section for an illustration.
-#' 
+#'
 #' @param obj object whose name at a given parent generation is of interest.
 #' @param n number of parent generations to go back from the calling environment
 #' to retrieve the name of the object that leads to \code{obj}
@@ -17,39 +17,39 @@
 #' getting the object's name in that environment. See details for more information.
 #' @param silent when \code{FALSE}, the names of the environments and objects in those environments are printed
 #' as those environments are traversed by this function.
-#' 
+#'
 #' @return The name of the object in the \code{n}-th parent generation environment.
-#' 
-#' @details 
+#'
+#' @details
 #' This function goes back to each parent generation from the calling function's environment
 #' and at each of those parent generations it retrieves the name of the object that is part of
 #' the parameter chain leading to the calling function's parameter.
-#' 
+#'
 #' To illustrate: suppose we call a function \code{f <- function(x)} by running the piece of code \code{f(z)},
-#' and that \code{f} calls another function \code{g <- function(y)} by running the piece of code \code{g(x)}.  
-#' 
-#' That is, we have the parameter chain:  
+#' and that \code{f} calls another function \code{g <- function(y)} by running the piece of code \code{g(x)}.
+#'
+#' That is, we have the parameter chain:
 #' \code{z -> x -> y}
-#' 
-#' If, inside function \code{g()}, we call \code{get_obj_name()} as follows, we obtain respectively:  
+#'
+#' If, inside function \code{g()}, we call \code{get_obj_name()} as follows, we obtain respectively:
 #' \code{get_obj_name(y, n=1)} yields \code{"x"}
 #' \code{get_obj_name(y, n=2)} yields \code{"z"}
-#' 
+#'
 #' because these calls are telling "give me the name of object \code{y} as it was called
 #' \code{n} levels up from the calling environment --i.e. from the environment of \code{g()}.
-#' 
+#'
 #' Note that the results of these two calls are different from making the following two
-#' \code{deparse(substitute())} calls:  
-#' \code{deparse(substitute(y, parent.frame(n=1)))}   
+#' \code{deparse(substitute())} calls:
+#' \code{deparse(substitute(y, parent.frame(n=1)))}
 #' \code{deparse(substitute(y, parent.frame(n=2)))}
 #' because these calls simply \code{substitute} or evaluate \code{y} at the \code{n}-th parent generation.
 #' If \code{y} is not defined at those parent generations, the \code{substitute()} calls return
 #' simply \code{"y"}.
-#' 
+#'
 #' On the contrary, the previous two calls to \code{get_obj_name()} return the name of the object
 #' in the parameter chain (\code{z -> x -> y}) \emph{leading} to \code{y}, which is a quite different
 #' piece of information.
-#' 
+#'
 #' When eval=TRUE, the result is the same as the result of \code{deparse()}
 #' except for the following three cases:
 #' \itemize{
@@ -60,7 +60,7 @@
 #' \item the result of a non-existent object is \code{NULL}, while \code{deparse()} returns an error stating
 #' that the object does not exist.
 #' }
-#' 
+#'
 #' When \code{get_obj_name} operates on non-existent objects it works at follows:
 #' \itemize{
 #' \item when \code{eval=FALSE} it returns the name of the non-existent object
@@ -68,19 +68,19 @@
 #' does not exist).
 #' \item when \code{eval=TRUE} it returns NULL.
 #' }
-#' 
+#'
 #' Finally \code{get_obj_name(NULL)} returns \code{NULL}, while \code{as.character(NULL)} returns \code{as.character(0)}.
-#' 
+#'
 #' @seealso
 #' \link{get_obj_value}
-#' 
+#'
 #' @examples
 #' # Example 1:
 #' # This example shows the difference between using get_obj_name() and deparse(substitute())
-#' g <- function(y) { return(list(obj_name=get_obj_name(y, n=2, silent=FALSE), 
+#' g <- function(y) { return(list(obj_name=get_obj_name(y, n=2, silent=FALSE),
 #'                                substitute=deparse(substitute(y, parent.frame(n=2))) )) }
 #' f <- function(x) { g(x) }
-#' z = 3; 
+#' z = 3;
 #' f(z)           # After showing the names of objects as they
 #'                # are traversed in the parameter chain (silent=FALSE),
 #'                # this function returns a list where
@@ -98,7 +98,7 @@
 #' g <- function(y) { return(list(obj_name=get_obj_name(y, n=2, eval=TRUE),
 #'                                deparse=deparse(y))) }
 #' f <- function(x) { g(x) }
-#' z = 3 
+#' z = 3
 #' f(z)           # Returns a list where both elements are equal to "3"
 #'                # because the output of get_obj_name() with eval=TRUE
 #'                # and deparse() are the same.
@@ -124,7 +124,7 @@
 #'   }
 #' }
 #' z = 5
-#' extra_param = "a '...' parameter" 
+#' extra_param = "a '...' parameter"
 #'   ## Note: this exra parameter is NOT shown neither by get_obj_name()
 #'   ## nor by as.list(environment())
 #' f("test", z, extra_param)
@@ -143,7 +143,7 @@ get_obj_name = function(obj, n=0, eval=FALSE, silent=TRUE) {
     # Show the environment where the process starts: this is the environment of the calling function
     env_back = parent.frame(n=1)
     fun_calling = environment_name(env_back)
-    cat("Start at environment ", fun_calling, ", object name is '", deparse(obj_parent), "'\n", sep="")
+    cat("Start at environment ", fun_calling, ", object name is '", paste(deparse(obj_parent), collapse = "\n"), "'\n", sep="")
   }
 
   # Iterate on the calling chain to get the name of the object passed to thie function
@@ -159,7 +159,7 @@ get_obj_name = function(obj, n=0, eval=FALSE, silent=TRUE) {
     if (is.environment(obj_parent)) {
       obj_parent = eval.parent(obj_parent, nback)
     } else {
-      expr = parse(text=paste("substitute(", deparse(obj_parent), ")"))
+      expr = parse(text=paste("substitute(", paste(deparse(obj_parent), collapse = "\n"), ")"))
       obj_parent = eval.parent(expr, nback)
     }
     if (!silent) {
@@ -172,7 +172,7 @@ get_obj_name = function(obj, n=0, eval=FALSE, silent=TRUE) {
       # get_obj_name(), which is what the user "sees".
       env_back = parent.frame(n=nback+1)
       fun_calling = environment_name(env_back)
-      cat("Level ", nback, " back: environment = ", fun_calling, ", object name is '", deparse(obj_parent), "'\n", sep="")
+      cat("Level ", nback, " back: environment = ", fun_calling, ", object name is '", paste(deparse(obj_parent), collapse = "\n"), "'\n", sep="")
     }
     nback = nback + 1
   }
@@ -214,7 +214,7 @@ get_obj_name = function(obj, n=0, eval=FALSE, silent=TRUE) {
     obj_parent_name = environment_name(obj_parent)
   } else {
     # In regular cases, get the object name by simply calling deparse()
-    obj_parent_name = deparse(obj_parent)
+    obj_parent_name = paste(deparse(obj_parent), collapse = "\n")
   }
 
   # Check if obj_parent was already a string before deparsing

--- a/tests/testthat/test-get_obj_address.r
+++ b/tests/testthat/test-get_obj_address.r
@@ -270,6 +270,13 @@ test_that("T3OLD) the address of an object passed as a string is correctly retur
   expect_equal(get_obj_address("env1"), expected)
   expect_equal(get_obj_address("x", envir=globalenv()$env1), envnames:::address(globalenv()$env1$x))
 })
+
+test_that("Empty data frames and lists do not cause errors", {
+  # Related to issue #12
+  expect_no_error(get_obj_address(data.frame()))
+  expect_no_error(get_obj_address(list()))
+})
+
 #---------------------------------- Extreme cases -----------------------------------
 
 # 3.- Cleanup -------------------------------------------------------------

--- a/tests/testthat/test-get_obj_name.r
+++ b/tests/testthat/test-get_obj_name.r
@@ -396,7 +396,13 @@ test_that("T93) the name of NULL is NULL, and the name of NA is \"NA\", regardle
   expect_equal( get_obj_name(NA, eval=FALSE), "NA" )
   expect_equal( get_obj_name(NA, eval=TRUE), "NA" )
 })
-# Extreme cases -----------------------------------------------------------
+
+test_that("objects deparsing to more than 60 characters do not cause an error", {
+  # related to #12
+  expect_no_error(
+    get_obj_name(data.frame(x = 1:8, y = c("a", "b", "c", "d", "e", "f", "g", "h")), n = 1)
+  )
+})
 
 
 # 3.- Cleanup -------------------------------------------------------------

--- a/tests/testthat/test-get_obj_name.r
+++ b/tests/testthat/test-get_obj_name.r
@@ -101,7 +101,7 @@ test_that("T4) the name of objects inside environments are correctly returned", 
   expected = "x"
   observed = with(env1, get_obj_name(x))
   expect_equal(observed, expected)
-  
+
   expected = "env1$x"
   observed = get_obj_name(env1$x)
   expect_equal(observed, expected)
@@ -120,7 +120,7 @@ test_that("T11) the name of user-defined environments when given through their v
   expected = "env1"
   observed = get_obj_name(env1)
   expect_equal(observed, expected)
-  
+
   expected = "env_of_envs$env2"
   observed = get_obj_name(env_of_envs$env2)
   expect_equal(observed, expected)
@@ -162,10 +162,10 @@ test_that("T12b) (eval=TRUE) the name of unnamed environments
 
   # User-defined environment (given by its address as we do by using 'globalenv()$' in front of the environment name)
   expect_equal(get_obj_name(globalenv()$env1, eval=TRUE), "env1")
-            
+
   # Function execution environment
   expect_equal(get_obj_name(environment(), eval=TRUE), "base$eval")
-  
+
   # Test the case where we retrieve the name of an unnamed environment deep down in the calling chain
   # (so that the loop performed on nback in get_obj_name is actually tested on function execution environments!
   # (which are given in the form <environment: 0x000000001b485670>))
@@ -261,7 +261,7 @@ test_that("T21) Object names are correcly returned when eval=FALSE at different 
   expect_equal( h(fNull, n=1, silent=silent), names(as.list(h))[1] )
 })
 
-test_that("T22) The value returned when eval=TRUE is the same as the return value of deparse() and doesn't change with n.
+test_that("T22) The value returned when eval=TRUE is the same as the return value of deparse() (converted to single string) and doesn't change with n.
           In fact, the value of the object that is passed through different functions is always the same inside each function!", {
   silent = TRUE
 
@@ -269,13 +269,13 @@ test_that("T22) The value returned when eval=TRUE is the same as the return valu
   expect_equal( h(v[2], n=2, eval=TRUE, silent=silent), v[2] )
   expect_equal( h(v[2], n=1, eval=TRUE, silent=silent), v[2] )
   expect_equal( h(v[2], n=0, eval=TRUE, silent=silent), v[2] )
-  
+
   # When the object passed is a more complicated object (vector, function, etc.)
   expect_equal( h(v, n=0, eval=TRUE, silent=silent), deparse(v) )
   expect_equal( h(v, n=1, eval=TRUE, silent=silent), deparse(v) )
   expect_equal( h(fNull(), n=0, eval=TRUE, silent=silent), NULL )
-  expect_equal( h(fNull, n=0, eval=TRUE, silent=silent), deparse(fNull) )
-  expect_equal( h(fNull, n=1, eval=TRUE, silent=silent), deparse(fNull) )
+  expect_equal( h(fNull, n=0, eval=TRUE, silent=silent), paste(deparse(fNull), collapse = "\n"))
+  expect_equal( h(fNull, n=1, eval=TRUE, silent=silent), paste(deparse(fNull), collapse = "\n"))
 })
 # Tests on n > 0 ----------------------------------------------------------
 
@@ -287,12 +287,12 @@ test_that("T31) the function works on arrays and lists and using sapply()", {
   expected = as.character(v[1])
   observed = get_obj_name(v[1], eval=TRUE)
   expect_equal(observed, expected)
-  
+
   # Out of range element
   expected = "NA_character_"
   observed = get_obj_name(v[5], eval=TRUE)
   expect_equal(observed, expected)
-  
+
   # sapply()
   expected = as.character(v)
   names(expected) = v
@@ -309,7 +309,7 @@ test_that("T31) the function works on arrays and lists and using sapply()", {
   expected = as.character(alist[[1]])  # Note that deparse(alist[1]) gives "\"x\"", and as.character() returns "x"
   observed = get_obj_name(alist[[1]], eval=TRUE)
   expect_equal(observed, expected)
-  
+
   # Out of range element as a vector
   expected = deparse(alist[5])
   observed = get_obj_name(alist[5], eval=TRUE)  # Note that calling alist[[5]] gives "out of bounds" error
@@ -318,13 +318,13 @@ test_that("T31) the function works on arrays and lists and using sapply()", {
   expected = NULL   # (2017/03/17) get_obj_name() returns "alist[[5]]"... I think it should return NULL...
   observed = get_obj_name(alist[[5]], eval=TRUE)  # Note that calling alist[[5]] gives "out of bounds" error
   expect_equal(observed, expected)
-  
+
   # sapply()
   expected = as.character(alist)
   names(expected) = names(alist)
   observed = sapply(alist, get_obj_name, eval=TRUE)
   expect_equal(observed, expected)
-  
+
   #--- List of quoted objects
   # On one element as a vector
   expected = deparse(alist_quoted[1])  # This is "list(x)" NOT "x"
@@ -334,12 +334,12 @@ test_that("T31) the function works on arrays and lists and using sapply()", {
   expected = "x"
   observed = get_obj_name(alist_quoted[[1]], eval=TRUE)
   expect_equal(observed, expected)
-  
+
   # sapply()
   expected = as.character(alist_quoted)
   observed = sapply(alist_quoted, get_obj_name, eval=TRUE)
   expect_equal(observed, expected)
-  
+
   #--- List of expressions (e.g. functions, array elements, etc.)
   # On one element as a list element
   expected = "fNull()"


### PR DESCRIPTION
This PR:

- changes all `deparse(obj_parent)` calls in get_obj_name to `paste(deparse(obj_parent), collapse = "\n")`: parts of this function and get_obj_addr() expect this to return a single string. This preserves the line breaks done by deparse() but converts them from a vector of strings to a single one
- adds an `isTRUE()` check around get_obj_addr()'s `is_obj_null_na_string`: is_obj_null_na_string could sometimes evaluate to na, for example with an empty `data.frame()` as input (this for example leads to is.string() returning a 2D matrix I think, and || turns that into NA)

I'm sorry for all the whitespace changes. I forgot to turn off my edior's setting to remove trailing whitespace.

I am also unsure whether `isTRUE()` or `!isFALSE()` or a more differentiated distinction is the correct approach to handle edge cases for `is_obj_null_na_string`. I decided to err on the side of caution with isTRUE() which makes any NA value lead to get_obj_addr() just returning null.

One test still reports an error on my machine Windows, R4.5.0: T21) specifying include_functions=TRUE returns ALL the function environments where the object is found ── Error in `eval(code, test_env)`: The test did NOT pass in any of its forms.

I checked and the same error is reported on the current state of the master branch.

closes #12 